### PR TITLE
DRY up setup.py and get dependencies in place to start testing

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+addopts =
+    -vv
+    --showlocals
+testpaths = tests

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,0 +1,6 @@
+flake8~=3.5
+flake8-docstrings
+flake8-future-import
+flake8-import-order
+pdbpp~=0.9
+pytest~=3.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
-psycopg2
-requests==2.12.4
-chardet==2.3.0
 aiodns==1.1.1
 aiohttp==1.3.3
+chardet==2.3.0
+click~=6.7
+psycopg2~=2.7
+requests==2.12.4
+
 # if using jupyter notebooks
 #jupyter==1.0.0
 #notebook==4.3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,42 @@
-from setuptools import setup, find_packages
+import sys
+
+from setuptools import find_packages, setup
+
+
+def req_reader(filename):
+    with open(filename) as f:
+        return [
+            requirement
+            for requirement in f.read().splitlines()
+            if requirement and requirement.strip() and not requirement.strip().startswith('#')
+        ]
+
+
+with open('README.md', 'r') as f:
+    long_description = f.read()
+
+requires = req_reader('requirements.txt')
+tests_require = req_reader('requirements.test.txt')
+setup_requires = []
+extras_require = {
+    'test': tests_require,
+}
+
+# Only require pytest-runner for certain setup.py commands
+needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
+pytest_runner = ['pytest-runner'] if needs_pytest else []
 
 setup(
     name='ttc_api_scraper',
     version='0.3',
     description="Script to pull data from the TTC's Subway API and store them in a database",
+    long_description=long_description,
     packages=find_packages(),
-    install_requires=[
-        'click',
-        'psycopg2',
-        'aiohttp',
-        'async_timeout',
-        'requests'
-    ],
-    python_requires='>=3',
+    install_requires=requires,
+    setup_requires=setup_requires + pytest_runner,
+    tests_require=tests_require,
+    extras_require=extras_require,
+    python_requires='>=3,<3.7.0',
     entry_points='''
         [console_scripts]
         ttc_api_scraper=ttc_api_scraper:main


### PR DESCRIPTION
This cleans up the `setup.py` file so that it uses the `requirements.txt` to specify the dependencies. That way we dont get any conflicting requirements. I also set up the `requirements.test.txt` file which we can start adding to when tests get added to the project.

There are 2 ways you can try this out:
- `python setup.py test` (or python3 depending on your OS)
- `pip install -r requirements.txt -r requirements.test.txt` and then `pytest`

Example:
```
⇒  python setup.py test
running pytest
running egg_info
creating ttc_api_scraper.egg-info
writing ttc_api_scraper.egg-info/PKG-INFO
writing dependency_links to ttc_api_scraper.egg-info/dependency_links.txt
writing entry points to ttc_api_scraper.egg-info/entry_points.txt
writing requirements to ttc_api_scraper.egg-info/requires.txt
writing top-level names to ttc_api_scraper.egg-info/top_level.txt
writing manifest file 'ttc_api_scraper.egg-info/SOURCES.txt'
reading manifest file 'ttc_api_scraper.egg-info/SOURCES.txt'
writing manifest file 'ttc_api_scraper.egg-info/SOURCES.txt'
running build_ext
============================================================================= test session starts ==============================================================================
platform linux -- Python 3.6.6, pytest-3.8.2, py-1.6.0, pluggy-0.7.1 -- /home/perobertson/.pyenv/versions/3.6.6/bin/python
cachedir: .pytest_cache
rootdir: /home/perobertson/workspace/ttc_subway_times, inifile: pytest.ini
collected 0 items                                                                                                                                                              

========================================================================= no tests ran in 0.00 seconds =========================================================================
```