### PR TITLE
initial ci setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,57 @@
+version: 2.1
+commands:
+  tox:
+    parameters:
+      env:
+        type: string
+    steps:
+      - checkout
+      - run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          pip install --user tox
+          tox -e << parameters.env >>
+
+jobs:
+  linters:
+    docker:
+      - image: python:3.6-slim
+    working_directory: ~/repo
+    steps:
+      - tox:
+          env: linters
+
+  py35:
+    docker:
+      - image: python:3.5-slim
+    working_directory: ~/repo
+    steps:
+      - tox:
+          env: py35
+
+  py36:
+    docker:
+      - image: python:3.6-slim
+    working_directory: ~/repo
+    steps:
+      - tox:
+          env: py36
+
+  py37:
+    docker:
+      - image: python:3.7-slim
+    working_directory: ~/repo
+    steps:
+      - run: apt-get update
+      - run: apt-get install -y build-essential
+      - tox:
+          env: py37
+
+
+workflows:
+  version: 2
+  workflow:
+    jobs:
+      - linters
+      - py35
+      - py36
+      - py37

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import generator_stop

--- a/tests/test_ttc_api_scraper.py
+++ b/tests/test_ttc_api_scraper.py
@@ -1,0 +1,25 @@
+from __future__ import generator_stop
+
+from click.testing import CliRunner
+
+from ttc_api_scraper import cli
+
+
+def test_help():
+    runner = CliRunner()
+    result = runner.invoke(cli, ['--help'])
+    assert result.output.startswith('Usage:')
+    assert 'Show this message and exit.' in result.output
+    assert 0 == result.exit_code
+
+    # Make sure commands are listed
+    lines = result.output.split('\n')
+    for idx, line in enumerate(lines):
+        if line == 'Commands:':
+            assert '  archive  Download month (YYYYMM) of data from database...' == lines[idx + 1]
+            assert '  scrape   Run the scraper' == lines[idx + 2]
+            assert '' == lines[idx + 3]
+            assert idx + 3 == len(lines) - 1
+            break
+    else:
+        assert False, 'Cannot find commands in output'

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,30 @@
+[tox]
+envlist = py35,py36,py37,flake8,linters
+
+[testenv]
+deps = .[test]
+commands = {posargs:pytest}
+
+# Linters
+[testenv:flake8]
+basepython = python3
+deps = .[test]
+commands =
+    flake8
+
+[testenv:linters]
+basepython = python3
+deps =
+    {[testenv:flake8]deps}
+commands =
+    {[testenv:flake8]commands}
+
+# Release tooling
+[testenv:build]
+basepython = python3
+skip_install = true
+deps =
+    wheel
+    setuptools
+commands =
+    python setup.py -q sdist bdist_wheel


### PR DESCRIPTION
This gets the initial setup of continuous integration on [CircleCI](https://circleci.com/) setup. Its going to come in handy for discovering why something does not work the way it should.

I have set it up so that it does a series of lint checks and will run tests on python3.5, 3.6, and 3.7. The lint checks will help prevent common pitfalls as well as following conventions set in place by the [pep8 rules](https://www.python.org/dev/peps/pep-0008/). These tests will initially fail, but that is the plan. Once this is merged in we can iterate on it and configure the checks and decide what we do and do not want to enforce.

To try this out locally, you need `tox` installed `pip install --user tox` and then do `tox -e py35` or `tox -e py36` depending on your local python version.