### PR TITLE
switch cronic to use spaces

### DIFF
--- a/cronic.py
+++ b/cronic.py
@@ -5,30 +5,30 @@ import subprocess
 from datetime import datetime
 
 def run_parallel():
-	while True:
-		subprocess.Popen("python ttc_api_scraper.py", shell = True)
-		sleep(10)
+    while True:
+        subprocess.Popen("python ttc_api_scraper.py", shell = True)
+        sleep(10)
 
 def run_blocking():
-	period = 10
-	while True:
-		st = datetime.now()
-		# sleep 5 mins then check time again if after operating hours
-		if ((st.hour >= 2 and st.minute > 15) or (st.hour >= 3)) and ((st.hour < 5) or (st.hour < 6 and st.minute < 45)): 
-			sleep(300)
-			print("After operating hours: " + str(st) + " -- Sleeping 5 mins.")
-			continue
+    period = 10
+    while True:
+        st = datetime.now()
+        # sleep 5 mins then check time again if after operating hours
+        if ((st.hour >= 2 and st.minute > 15) or (st.hour >= 3)) and ((st.hour < 5) or (st.hour < 6 and st.minute < 45)):
+            sleep(300)
+            print("After operating hours: " + str(st) + " -- Sleeping 5 mins.")
+            continue
 
-		subprocess.run("python ttc_api_scraper.py", shell = True)
-		et = datetime.now()
-		delta = et-st
-		if(delta.seconds < period):
-			sleep(period - delta.seconds)
+        subprocess.run("python ttc_api_scraper.py", shell = True)
+        et = datetime.now()
+        delta = et-st
+        if(delta.seconds < period):
+            sleep(period - delta.seconds)
 
 
 def main():
-	# run_parallel()
-	run_blocking()
+    # run_parallel()
+    run_blocking()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
https://www.python.org/dev/peps/pep-0008/#tabs-or-spaces

Most of our code is already using spaces, so going tabs to spaces will be easier.

When we enable flake8 for checks, this will fix [E101](https://github.com/CivicTechTO/ttc_subway_times/pull/42/files#diff-380c6a8ebbbce17d55d50ef17d3cf906R31) and [W191](https://github.com/CivicTechTO/ttc_subway_times/pull/42/files#diff-380c6a8ebbbce17d55d50ef17d3cf906R97)