### PR TITLE
lint - prevent tabs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,8 +27,6 @@ ignore =
   D400,
   ; Missing blank line after last section
   D413,
-  ; indentation contains mixed spaces and tabs
-  E101,
   ; closing bracket does not match visual indentation
   E124,
   ; continuation line over-indented for visual indent
@@ -93,8 +91,6 @@ ignore =
   N802,
   ; variable 'ntasData' in function should be lowercase
   N806,
-  ; indentation contains tabs
-  W191,
   ; trailing whitespace
   W291,
   ; no newline at end of file


### PR DESCRIPTION
Just a follow up to https://github.com/CivicTechTO/ttc_subway_times/pull/44 where the tabs got removed. I forgot to enforce the linter at that time.